### PR TITLE
Fix config paths and add defaults

### DIFF
--- a/docker/setup/entrypoint.sh
+++ b/docker/setup/entrypoint.sh
@@ -28,7 +28,7 @@ echo "[✓] SSH setup complete — container is staying alive."
 #####       SysAdmin Simulator Configuration Script             #####
 #####################################################################
 
-CONFIG_DIR="$HOME/etc/.sysadmin-simulator"
+CONFIG_DIR="$HOME/.config/sysadmin-sim"
 CONFIG_FILE="$CONFIG_DIR/config.yaml"
 CONFIG_SCRIPT="/bin/sysadmin-sim/sysadmin-sim-config.sh"
 

--- a/src/config/default.yaml
+++ b/src/config/default.yaml
@@ -1,0 +1,4 @@
+game_mode: Exam
+exam_target: Linux+
+timer_display: prompt
+difficulty: easy

--- a/src/scripts/sysadmin-sim-config.sh
+++ b/src/scripts/sysadmin-sim-config.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 
-CONFIG_DIR="$HOME/.config/sysadmin-simulator"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$HOME/.config/sysadmin-sim"
 CONFIG_FILE="$CONFIG_DIR/config.yaml"
-DEFAULT_CONFIG="/src/config/default.yaml"
+DEFAULT_CONFIG="$SCRIPT_DIR/../config/default.yaml"
 
 # Create config directory if it doesn't exist
 mkdir -p "$CONFIG_DIR"
 
-# If no config exists, copy the default
+# If no config exists, seed with defaults
 if [[ ! -f "$CONFIG_FILE" ]]; then
-    cp "$DEFAULT_CONFIG" "$CONFIG_FILE"
+    if [[ -f "$DEFAULT_CONFIG" ]]; then
+        cp "$DEFAULT_CONFIG" "$CONFIG_FILE"
+    else
+        cat <<EOF > "$CONFIG_FILE"
+game_mode: Exam
+exam_target: Linux+
+timer_display: prompt
+difficulty: easy
+EOF
+    fi
 fi
 
 function show_menu() {
@@ -57,8 +67,17 @@ function configure() {
                 echo "Current Configuration:"
                 cat "$CONFIG_FILE"
                 ;;
-            6) 
-                cp "$DEFAULT_CONFIG" "$CONFIG_FILE"
+            6)
+                if [[ -f "$DEFAULT_CONFIG" ]]; then
+                    cp "$DEFAULT_CONFIG" "$CONFIG_FILE"
+                else
+                    cat <<EOF > "$CONFIG_FILE"
+game_mode: Exam
+exam_target: Linux+
+timer_display: prompt
+difficulty: easy
+EOF
+                fi
                 echo "[+] Reset to default configuration."
                 ;;
             0) 


### PR DESCRIPTION
## Summary
- create `src/config/default.yaml` with basic defaults
- standardize config path to `~/.config/sysadmin-sim` in `sysadmin-sim-config.sh`
- update entrypoint to use the same config location
- ensure config file is created with defaults when missing

## Testing
- `bash -n src/scripts/sysadmin-sim-config.sh`
- `bash -n docker/setup/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68424628781c832180b3dbfed0ba17ee