### PR TITLE
Fix quoting in ticket-017 setup

### DIFF
--- a/src/setup/ticket-017-setup.sh
+++ b/src/setup/ticket-017-setup.sh
@@ -11,6 +11,6 @@ SLEEP_PID=$!
 mkdir -p /opt/ticket-017/
 echo "$SLEEP_PID" > /opt/ticket-017/expected-pid.txt
 
-echo "[+] Sleep process started successfully.  
+echo "[+] Sleep process started successfully."
 exit 0
 


### PR DESCRIPTION
## Summary
- fix typo in echo statement of ticket-017 setup script

## Testing
- `bash -n src/setup/ticket-017-setup.sh`
- `bash src/checks/ticket-017-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842485cfe8c8321a05c1fdad74e2f3a